### PR TITLE
chore: release v0.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,6 @@ jobs:
       - name: Run tests
         run: cargo test
 
-  # Update this to use releaze plz  
-  # release:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: google-github-actions/release-please-action@v3
-  #       with:
-  #         release-type: rust
-  #         package-name: release-please-action
-
-
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.3](https://github.com/jearle10/cscart-rs/compare/v0.5.2...v0.5.3) - 2024-03-06
+
+### Other
+- release-plz
+- release-plz
+
 ## [0.5.0](https://github.com/jearle10/cscart-rs/compare/v0.4.2...v0.5.0) (2023-06-18)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.5.2"
+version = "0.5.3"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.5.1"
+version = "0.5.2"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION
## 🤖 New release
* `cscart-rs`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.3](https://github.com/jearle10/cscart-rs/compare/v0.5.2...v0.5.3) - 2024-03-06

### Other
- release-plz
- release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).