### PR TITLE
chore: release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.5](https://github.com/jearle10/cscart-rs/compare/v0.5.4...v0.5.5) - 2024-05-15
+
+### Fixed
+- circular ci
+
 ## [0.5.4](https://github.com/jearle10/cscart-rs/compare/v0.5.3...v0.5.4) - 2024-05-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.5.4"
+version = "0.5.5"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION
## 🤖 New release
* `cscart-rs`: 0.5.4 -> 0.5.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.5](https://github.com/jearle10/cscart-rs/compare/v0.5.4...v0.5.5) - 2024-05-15

### Fixed
- circular ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).