### PR TITLE
chore: release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.5.6](https://github.com/jearle10/cscart-rs/compare/v0.5.5...v0.5.6) - 2024-05-19
+
+### Added
+- Add OrderDetails type
+- Add OrderDetails type
+- Add OrderDetails type
+
+### Fixed
+- update serde_utils deserializers
+
+### Other
+- Remove .vscode
+- Add OrderDetails type
+- update
+
 ## [0.5.5](https://github.com/jearle10/cscart-rs/compare/v0.5.4...v0.5.5) - 2024-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,12 @@
 
 ### Added
 - Add OrderDetails type
-- Add OrderDetails type
-- Add OrderDetails type
 
 ### Fixed
 - update serde_utils deserializers
 
 ### Other
 - Remove .vscode
-- Add OrderDetails type
-- update
 
 ## [0.5.5](https://github.com/jearle10/cscart-rs/compare/v0.5.4...v0.5.5) - 2024-05-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.5.5"
+version = "0.5.6"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION
## 🤖 New release
* `cscart-rs`: 0.5.5 -> 0.5.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.6](https://github.com/jearle10/cscart-rs/compare/v0.5.5...v0.5.6) - 2024-05-19

### Added
- Add OrderDetails type
- Add OrderDetails type
- Add OrderDetails type

### Fixed
- update serde_utils deserializers

### Other
- Remove .vscode
- Add OrderDetails type
- update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).