### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0](https://github.com/jearle10/cscart-rs/compare/v0.5.6...v0.6.0) - 2024-05-24
+
+### Other
+- More types ([#32](https://github.com/jearle10/cscart-rs/pull/32))
+
 ## [0.5.6](https://github.com/jearle10/cscart-rs/compare/v0.5.5...v0.5.6) - 2024-05-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.5.6"
+version = "0.6.0"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION
## 🤖 New release
* `cscart-rs`: 0.5.6 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/jearle10/cscart-rs/compare/v0.5.6...v0.6.0) - 2024-05-24

### Other
- More types ([#32](https://github.com/jearle10/cscart-rs/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).