### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.7.0](https://github.com/jearle10/cscart-rs/compare/v0.6.0...v0.7.0) - 2024-06-03
+
+### Added
+- Remaining types added
+
+### Other
+- udpate readme
+- Cargo fix
+- Update README.md
+- Internal refactoring
+
 ## [0.6.0](https://github.com/jearle10/cscart-rs/compare/v0.5.6...v0.6.0) - 2024-05-24
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.6.0"
+version = "0.7.0"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION
## 🤖 New release
* `cscart-rs`: 0.6.0 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/jearle10/cscart-rs/compare/v0.6.0...v0.7.0) - 2024-06-03

### Added
- Remaining types added

### Other
- udpate readme
- Cargo fix
- Update README.md
- Internal refactoring
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).