### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.8.0](https://github.com/jearle10/cscart-rs/compare/v0.7.0...v0.8.0) - 2025-03-30
+
+### Added
+
+- Auth, Block, Order types API responses
+- Auth, Block, Order types API responses
+
+### Fixed
+
+- temperamental test
+- cicd
+- cicd
+
+### Other
+
+- remove debug
+- User service and make products fields all public
+- Vendor service types
+- Vendor service types
+- Product service types
+- Cart service types
+- Cart service types
+- All tests passing, categories typing done, auth link bug resolved
+
 ## [0.7.0](https://github.com/jearle10/cscart-rs/compare/v0.6.0...v0.7.0) - 2024-06-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.7.0"
+version = "0.8.0"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION



## 🤖 New release

* `cscart-rs`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `cscart-rs` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct cscart_rs::prelude::CartProduct, previously in file /tmp/.tmpbCsryz/cscart-rs/src/types/call_request.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/jearle10/cscart-rs/compare/v0.7.0...v0.8.0) - 2025-03-30

### Added

- Auth, Block, Order types API responses
- Auth, Block, Order types API responses

### Fixed

- temperamental test
- cicd
- cicd

### Other

- remove debug
- User service and make products fields all public
- Vendor service types
- Vendor service types
- Product service types
- Cart service types
- Cart service types
- All tests passing, categories typing done, auth link bug resolved
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).