### PR TITLE
Release cscart-rs v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.1](https://github.com/jearle10/cscart-rs/compare/v0.8.0...v0.8.1) - 2025-03-31
+
+### Fixed
+
+- tweak cicd
+- tweak cicd
+
 ## [0.8.0](https://github.com/jearle10/cscart-rs/compare/v0.7.0...v0.8.0) - 2025-03-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cscart-rs"
 description = "An sdk for the cs-cart e-commerce platform"
 license = "MIT OR Apache-2.0"
-version = "0.8.0"
+version = "0.8.1"
 authors =  ["Jian Earle"]
 edition = "2021"
 keywords = ["sdk" , "ecommerce" , "cscart"]


### PR DESCRIPTION


## 🤖 New release

* `cscart-rs`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/jearle10/cscart-rs/compare/v0.8.0...v0.8.1) - 2025-03-31

### Fixed

- tweak cicd
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).